### PR TITLE
fix: add missing dependencies after upgrading Docusaurus to 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,18 @@
 		"react-dom": "^18",
 		"react-player": "^2",
 		"redocusaurus": "^2",
-		"url": "^0"
+		"url": "*",
+		"react-loadable": "*",
+		"typescript": ">2.7",
+		"@types/react": ">16",
+		"search-insights": ">=1 <3",
+		"@algolia/client-search": ">=4.9.1 <6",
+		"@docusaurus/theme-common": "^3",
+		"@docusaurus/theme-classic": ">=2.2.0",
+		"@docusaurus/utils": "^3.0.0",
+		"webpack": "^5.0.0",
+		"core-js": "^3.1.4",
+		"mobx": "^6.0.4",
+		"styled-components": "^6.0.5"
 	}
 }


### PR DESCRIPTION
This MR adds some missing Dependencies required for Docusaurus to run with no drama & warnings.